### PR TITLE
Update job spec to match actual

### DIFF
--- a/rundeck/job.yaml
+++ b/rundeck/job.yaml
@@ -94,7 +94,7 @@ paths:
         in: path
         required: True
         description: Job ID
-        type: integer
+        type: string
       - name: request
         in: body
         required: false
@@ -102,7 +102,7 @@ paths:
       responses:
         '200':
           description: Expected response for a valid request
-          schema: {$ref: '#/definitions/ExecutionList'}
+          schema: {$ref: '#/definitions/Execution'}
     delete:
       summary: Delete all job executions
       operationId: jobExecutionDelete


### PR DESCRIPTION
Job ID is a `UUID` these days => `string`.

Execution response in `JSON` is actually an individual execution info item.